### PR TITLE
Changed master '/error' route to be '/jade/error'

### DIFF
--- a/src/controllers/Browser-Controller.coffee
+++ b/src/controllers/Browser-Controller.coffee
@@ -56,6 +56,15 @@ class Browser_Controller
     else
       res.redirect '/jade'  +req.url
 
+  redirect_Error: (req, res)=>
+    if @.use_Flare(req)
+      if req.session?.username
+        res.redirect '/angular/user/error'
+      else
+        res.redirect '/angular/guest/error'
+    else
+      res.redirect '/jade/error'
+
   redirect_Search: (req, res)=>
     if @.use_Flare(req)
       res.redirect '/angular/user/index?text=' +req.query.text
@@ -92,6 +101,7 @@ class Browser_Controller
       @.get '/'                          , (req, res) -> browser_Controler.redirect_Root(req, res)
       @.get '/browser-detect'            , (req, res) -> browser_Controler.redirect_Root(req, res)
       @.get '/article/*'                 , (req, res) -> browser_Controler.redirect_Article(req, res)
+      @.get '/error'                     , (req, res) -> browser_Controler.redirect_Error(req, res)
       @.get '/search'                    , (req, res) -> browser_Controler.redirect_Search(req,res)
       @.get '/passwordReset/*'           , (req, res) -> browser_Controler.redirect_Pwd_Reset(req, res)
       @.get '/teammentor/open/:guid'     , (req, res) -> browser_Controler.redirect_TeamMentor_Open(req, res)

--- a/src/routes/routes.coffee
+++ b/src/routes/routes.coffee
@@ -68,8 +68,8 @@ add_Routes = (express_Service)->
     new PoC_Controller(options)        .register_Routes()
 
     #errors 404 and 500
-    app.get '/error', (req,res)-> res.status(500).send  jade_Service.render_Jade_File 'guest/500.jade',{ loggedIn:req.session?.username isnt undefined }
-    app.get '/*'    , (req,res)-> res.status(404).send  jade_Service.render_Jade_File 'guest/404.jade',{ loggedIn:req.session?.username isnt undefined }
+    app.get '/jade/error', (req,res)-> res.status(500).send  jade_Service.render_Jade_File 'guest/500.jade',{ loggedIn:req.session?.username isnt undefined }
+    app.get '/*'         , (req,res)-> res.status(404).send  jade_Service.render_Jade_File 'guest/404.jade',{ loggedIn:req.session?.username isnt undefined }
 
     app.use (err, req, res, next)->
       #console.error(err.stack)


### PR DESCRIPTION
Added browser detection (i.e. Jade vs Flare) to global '/error' path

Fix for https://github.com/TeamMentor/TM_4_0_Design/issues/995
